### PR TITLE
Replace System.stop/1 with Mix.raise/1

### DIFF
--- a/lib/mix/tasks/check_safety.ex
+++ b/lib/mix/tasks/check_safety.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.ExcellentMigrations.CheckSafety do
           |> Logger.warn()
         end)
 
-        System.stop(1)
+        Mix.raise("Dangerous operations detected in migrations!")
     end
   end
 end

--- a/lib/mix/tasks/migrate.ex
+++ b/lib/mix/tasks/migrate.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.ExcellentMigrations.Migrate do
           |> Logger.error()
         end)
 
-        System.stop(1)
+        Mix.raise("Dangerous operations detected in migrations!")
     end
   end
 end


### PR DESCRIPTION
This should ensure a non-zero exit status is returned when dangers are detected.

(Pulled from the original forked repo, because this seems like a valuable change to incorporate)